### PR TITLE
decrease updating timer to 1 hour

### DIFF
--- a/project/app/main.py
+++ b/project/app/main.py
@@ -72,7 +72,7 @@ app.include_router(getdata.router)
 
 
 @app.on_event('startup')
-@repeat_every(seconds=60*60*24)  # 24 hours
+@repeat_every(seconds=60*60*1)  # 1 hour
 def run_update() -> None:
     '''
     Update backlog database with data from reddit.


### PR DESCRIPTION
# Description
Decreases the timer that automatically updates the backlog to 1 hour from 24 hours
# Number of Files changed
1
# Questions for Reviewer

# Type of Change
- [ ] New Feature
- [x] Feature Update
- [ ] Fix Error

# Status
- [x] Tested
